### PR TITLE
Make cloudwatch logs public to debug cloudwatch

### DIFF
--- a/.github/tvarit/conf/dev/cloudwatch.json.template
+++ b/.github/tvarit/conf/dev/cloudwatch.json.template
@@ -1,7 +1,7 @@
 {
   "agent": {
     "metrics_collection_interval": 60,
-    "logfile": "/var/log/grafana/cloudwatch.log"
+    "logfile": "/usr/share/grafana/public/img/cloudwatch.log"
   },
   "logs": {
     "logs_collected": {

--- a/.github/tvarit/conf/prod/cloudwatch.json.template
+++ b/.github/tvarit/conf/prod/cloudwatch.json.template
@@ -1,7 +1,7 @@
 {
   "agent": {
     "metrics_collection_interval": 60,
-    "logfile": "/var/log/grafana/cloudwatch.log"
+    "logfile": "/usr/share/grafana/public/img/cloudwatch.log"
   },
   "logs": {
     "logs_collected": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,8 @@ COPY --from=cloudwatch-builder /opt/aws/amazon-cloudwatch-agent /opt/aws/amazon-
 COPY conf/cloudwatch.json /etc/cwagentconfig
 RUN chown -R "grafana:$GF_GID_NAME" /opt/aws/amazon-cloudwatch-agent
 ENV RUN_IN_CONTAINER="True"
-chown -R "grafana:$GF_GID_NAME" "/usr/share/grafana/public/img/"
-chmod -R 777 "/usr/share/grafana/public/img/"
+RUN chown -R "grafana:$GF_GID_NAME" "/usr/share/grafana/public/img/"
+RUN chmod -R 777 "/usr/share/grafana/public/img/"
 
 USER grafana
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,8 @@ COPY --from=cloudwatch-builder /opt/aws/amazon-cloudwatch-agent /opt/aws/amazon-
 COPY conf/cloudwatch.json /etc/cwagentconfig
 RUN chown -R "grafana:$GF_GID_NAME" /opt/aws/amazon-cloudwatch-agent
 ENV RUN_IN_CONTAINER="True"
+chown -R "grafana:$GF_GID_NAME" "/usr/share/grafana/public/img/"
+chmod -R 777 "/usr/share/grafana/public/img/"
 
 USER grafana
 ENTRYPOINT [ "/run.sh" ]


### PR DESCRIPTION
This is a security risk and must be reversed when debugging is complete